### PR TITLE
Fix `reallocarray()` on Win32

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -71,13 +71,9 @@ else
 endif
 config_h.set('HAVE_BIND_TEXTDOMAIN_CODESET', have_bind_textdomain_codeset)
 
-if cc.has_header('sys/resource.h')
-  config_h.set('HAVE_SYS_RESOURCE_H', 1)
-endif
-
-if cc.has_function('getrlimit')
-  config_h.set('HAVE_GETRLIMIT', 1)
-endif
+config_h.set('HAVE_SYS_RESOURCE_H', cc.has_header('sys/resource.h'))
+config_h.set('HAVE_GETRLIMIT', cc.has_function('getrlimit'))
+config_h.set('HAVE_REALLOCARRAY', cc.has_function('reallocarray', prefix: '#include <stdlib.h>'))
 
 configure_file(
   output: 'config.h',

--- a/src/kplot/reallocarray.c
+++ b/src/kplot/reallocarray.c
@@ -1,40 +1,45 @@
-/* $OpenBSD: reallocarray.c,v 1.1 2014/05/08 21:43:49 deraadt Exp $ */
+/* From: https://git.musl-libc.org/cgit/musl/commit/?id=821083ac7b54eaa040d5a8ddc67c6206a175e0ca */
 /*
- * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ * Copyright (c) 2005-2020 Rich Felker, et al.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
-#include <sys/types.h>
+ 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
 
 #include <errno.h>
-#include <stdint.h>
 #include <stdlib.h>
 
-/*
- * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
- * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
- */
-#define MUL_NO_OVERFLOW	(1UL << (sizeof(size_t) * 4))
+#ifndef HAVE_REALLOCARRAY
 
 void *
 reallocarray(void *optr, size_t nmemb, size_t size)
 {
-	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
-			nmemb > 0 && SIZE_MAX / nmemb < size) {
+	if (size && nmemb > -1 / size) {
 		errno = ENOMEM;
 		return NULL;
 	}
 
 	return realloc(optr, size * nmemb);
 }
+
+#endif /* !HAVE_REALLOCARRAY */


### PR DESCRIPTION
```
../nip4-9.0.1-2/src/kplot/reallocarray.c:33:16: warning: shift count >= width of type [-Wshift-count-overflow]
   33 |         if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
      |                       ^~~~~~~~~~~~~~~
../nip4-9.0.1-2/src/kplot/reallocarray.c:28:30: note: expanded from macro 'MUL_NO_OVERFLOW'
   28 | #define MUL_NO_OVERFLOW (1UL << (sizeof(size_t) * 4))
      |                              ^  ~~~~~~~~~~~~~~~~~~~~
../nip4-9.0.1-2/src/kplot/reallocarray.c:33:43: warning: shift count >= width of type [-Wshift-count-overflow]
   33 |         if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
      |                                                  ^~~~~~~~~~~~~~~
../nip4-9.0.1-2/src/kplot/reallocarray.c:28:30: note: expanded from macro 'MUL_NO_OVERFLOW'
   28 | #define MUL_NO_OVERFLOW (1UL << (sizeof(size_t) * 4))
      |                              ^  ~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```