### PR TITLE
Fix compile warnings

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -32,7 +32,9 @@
 /* A lot of this file is just for debugging. Uncomment to enable all the
  * debugging code.
  */
+/*
 #define DEBUG
+ */
 
 /* Dump a binary operator.
  */

--- a/src/view.c
+++ b/src/view.c
@@ -24,8 +24,8 @@
 /*
 #define DEBUG_VIEWCHILD
 #define DEBUG
- */
 #define DEBUG_LEAK
+ */
 
 /* Time each refresh
 #define DEBUG_TIME
@@ -44,10 +44,10 @@ static GSList *view_resettable = NULL;
 static GSList *all_view_widgets = NULL;
 #endif /*DEBUG_LEAK*/
 
-#ifdef DEBUG_LEAK
 void
 view_dump(void)
 {
+#ifdef DEBUG_LEAK
 	if (all_view_widgets) {
 		printf("view_dump(): %d views\n", g_slist_length(all_view_widgets));
 
@@ -63,8 +63,8 @@ view_dump(void)
 			printf("\n");
 		}
 	}
-}
 #endif /*DEBUG_LEAK*/
+}
 
 void
 view_scannable_register(View *view)


### PR DESCRIPTION
```
[1/2] Compiling C object src/nip4.p/dump.c.o
../src/dump.c:278:2: warning: #warning "DEBUG on in dump.c" [-Wcpp]
  278 | #warning "DEBUG on in dump.c"
      |  ^~~~~~~
[2/2] Compiling C object src/nip4.p/view.c.o
../src/view.c:43:2: warning: #warning "DEBUG_LEAK is on in view.c" [-Wcpp]
   43 | #warning "DEBUG_LEAK is on in view.c"
      |  ^~~~~~~
```