### PR TITLE
Meson: fix order-only dependencies on generated headers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -184,6 +184,7 @@ nip4_lib = static_library('nip4',
 )
 
 nip4_dep = declare_dependency(
+  sources: enumtypes[1],
   dependencies: nip4_deps,
   link_whole: nip4_lib,
 )


### PR DESCRIPTION
Ensures that `enumtypes.h` is generated before any files that `#include` it.

See: https://mesonbuild.com/FAQ.html#how-do-i-tell-meson-that-my-sources-use-generated-headers

As noticed in Homebrew:
https://github.com/Homebrew/homebrew-core/actions/runs/13788633964/job/38562929970#step:3:108